### PR TITLE
Update config_parser.py

### DIFF
--- a/dhalsim/parser/config_parser.py
+++ b/dhalsim/parser/config_parser.py
@@ -6,7 +6,8 @@ from datetime import datetime
 from pathlib import Path
 
 import yaml
-from yamlinclude import YamlIncludeConstructor
+# from yamlinclude import YamlIncludeConstructor
+from yaml_include import Constructor
 from schema import Schema, Or, And, Use, Optional, SchemaError, Regex
 
 from dhalsim.parser.input_parser import InputParser
@@ -626,9 +627,9 @@ class ConfigParser:
 
         self.config_path = config_path.absolute()
 
-        YamlIncludeConstructor.add_to_loader_class(loader_class=yaml.FullLoader,
-                                                   base_dir=config_path.absolute().parent)
-
+        # YamlIncludeConstructor.add_to_loader_class(loader_class=yaml.FullLoader,
+        #                                            base_dir=config_path.absolute().parent)
+        yaml.add_constructor("!include", Constructor(base_dir=config_path.absolute().parent), FullLoader)
         try:
             self.data = self.apply_schema(self.config_path)
         except SchemaError as exc:


### PR DESCRIPTION
in DHALSIM/dhalsim/parser/config_parser.py 

The Setup in installation has erros because of changes in yamlinclude:

* It seems that yamlinclude changed to yaml_include: https://pyyaml-include.readthedocs.io/en/main/README.html:
* In  2.0.a1 release (Date 2024-1-27) the tag constructor class YamlIncludeConstructor renamed to Constructor (https://pyyaml-include.readthedocs.io/en/main/CHANGELOG.html)
* the classmethod YamlIncludeConstructor.add_to_loader_class() was removed from [pyyaml-include 2.0's Constructor](https://github.com/tanbro/pyyaml-include/blob/v2.0.1/src/yaml_include/constructor.py). 

So, I've changed the file "DHALSIM/dhalsim/parser/config_parser.py " in:

* Line 9:

- `from yamlinclude import YamlIncludeConstructor`
+ `from yaml_include import Constructor`

and
* In line 629:
- `Constructor.add_to_loader_class(loader_class=yaml.FullLoader, base_dir=config_path.absolute().parent)`
+  `yaml.add_constructor("!include", Constructor(base_dir=config_path.absolute().parent), FullLoader)`

It worked for me!